### PR TITLE
Prep for 0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org).
 
+## Unsupported Release 0.1.1
+### Summary
+Minor bugfixes
+
 ## Unsupported Release 0.1.0
 ### Summary
 This is the first release of the Distelli Agent module.

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-distelli_agent",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "Puppet Inc",
   "summary": "Installs, configures, and manages the Distelli agent service.",
   "license": "Apache-2.0",


### PR DESCRIPTION
These changes have been sitting in master for 11 months without a Forge
release, while they are needed for some use cases. About time to just
roll them in.