### PR TITLE
CDPE-1583 fixes exec in unix.pp

### DIFF
--- a/manifests/agent/unix.pp
+++ b/manifests/agent/unix.pp
@@ -18,7 +18,7 @@ class pipelines::agent::unix {
   $agent_conf_file = '/etc/distelli.yml'
 
   exec { "mkdir ${install_dir}":
-    command => 'mkdir -p',
+    command => "mkdir -p ${install_dir}",
     path    => $facts['path'],
     creates => $install_dir,
   }


### PR DESCRIPTION
Currently, agent install fails if the install_dir does not exist on the system. It gets to the Exec[mkdir -p ] and mkdir returns 1 because no dir is passed as an argument, the command on the resource is just 'mkdir -p'. This change passes install_dir to the command param to make this behave as presumably intended.